### PR TITLE
Bump iDynTree version from v4.0.0 to v4.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "idyntree" %}
-{% set version = "4.0.0" %}
+{% set version = "4.1.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/robotology/idyntree/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 623675bc1ec40c0fbcde504203dd2ab022198da720e1ee078af5e2369b8a092e
+  sha256: a0021a007a55362a3467da8549502118871861f320aa00c2099c16a83b907175
 
 build:
   number: 0
@@ -47,6 +47,7 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
+    - meshcat-python
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This bumps the version of iDynTree to [`v4.1.0` ](https://github.com/robotology/idyntree/releases/tag/v4.1.0)
