### PR TITLE
 Remove meshcat-python dependency 

### DIFF
--- a/recipe/1046.patch
+++ b/recipe/1046.patch
@@ -1,0 +1,16 @@
+diff --git a/bindings/python/visualize/meshcat_visualizer.py b/bindings/python/visualize/meshcat_visualizer.py
+index 1c47361282..e59098bb5b 100644
+--- a/bindings/python/visualize/meshcat_visualizer.py
++++ b/bindings/python/visualize/meshcat_visualizer.py
+@@ -23,7 +23,10 @@ class MeshcatVisualizer:
+     """
+ 
+     def __init__(self, zmq_url=None):
+-        import meshcat
++        try:
++            import meshcat
++        except ModuleNotFoundError:
++            raise ModuleNotFoundError("the meshcat module is not found by the idyntree MeshcatVisualizer. Install explicitly meshcat-python via mamba install meshcat-python and try again.")
+ 
+         if zmq_url is not None:
+             print("Connecting to meshcat-server at zmq_url=" + zmq_url + ".")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,10 +8,12 @@ package:
 source:
   url: https://github.com/robotology/idyntree/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 883b60339319fd06f57aae9cdddedb02fa01b06bc3abfb278c881009cdf15c40
+  patches:
+    - 1046.patch
 
 build:
   skip: true  # [ppc64le]
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
@@ -59,7 +61,6 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - meshcat-python
 
 test:
   commands:


### PR DESCRIPTION
Users that wants it can install it explicitly.

Fix https://github.com/conda-forge/idyntree-feedstock/issues/54 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
