### PR TITLE
Remove pip and related dependencies from host

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [ppc64le]
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
@@ -38,10 +38,7 @@ requirements:
     - eigen
     - glfw
     - irrlicht
-    - pip
-    - python-build
     - python
-    - cmake-build-extension
     - numpy
     - libosqp
     - osqp-eigen


### PR DESCRIPTION
Since https://github.com/conda-forge/idyntree-feedstock/pull/20/files the python bindings are installed with pure cmake, so we should have removed also the related dependencies.

This fixes the linter error in https://github.com/conda-forge/idyntree-feedstock/pull/100#issuecomment-2306086992 .

@conda-forge-admin please rerender

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
